### PR TITLE
session: put style as line number to ssh session environment variable

### DIFF
--- a/session.c
+++ b/session.c
@@ -1188,6 +1188,11 @@ do_setup_env(struct ssh *ssh, Session *s, const char *shell)
 	if (original_command)
 		child_set_env(&env, &envsize, "SSH_ORIGINAL_COMMAND",
 		    original_command);
+	
+	/* Take advantage of authentication style field */
+	if (s->authctxt->style)
+		child_set_env(&env, &envsize, "SSH_TARGET_CONSOLE_LINE",
+			s->authctxt->style);
 
 	if (debug_flag) {
 		/* dump the environment */


### PR DESCRIPTION
# Overview

The style field in authctx were assigned in auth*.c

```bash
ssh username:style@hostname
```

The origin username is `username:style`, but the sshd will split it by `:` and then use `username` for authentication and put the `style` to authctx's style field.

This patch will take advantage of the style field for SONiC Console Switch reverse SSH feature:

```bash
ssh <username>:<line>@<host>
```

# Build & Installation Guide

## Build source code

Clone code and enter the source folder.

```bash
mkdir build && cd build
../configure --with-pam --with-md5-passwords
make
```

## Installation

If you has installed a `ssh-server` on your device, find it path by using `whereis sshd`.

Then stop sshd.

```bash
sudo service ssh stop
```

Copy your built sshd to the path you find in previous step.

```bash
sudo cp sshd <path_to_origin_sshd>
```

Start sshd.

```bash
sudo service ssh start
```

# Test & Verification

```bash
ssh admin:21@localhost
admin@localhost: echo $SSH_TARGET_LINE
21
```

# Progress

- [x] Test on Ubuntu WSL
- [x] Test on Azure Ubuntu VM
- [ ] Test on SONiC VS
- [ ] Test on SONiC Physical DUT